### PR TITLE
Make build.bat call-agnostic (fixes #5)

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,6 +1,15 @@
 @echo off
 
+set cd=%~dp0
+set build=%cd%build
+pushd %cd%
+IF NOT EXIST build (mkdir build)
+pushd %build%
+
 cl /nologo /GS- /Gs9999999 /Gm- /EHa- /GF /Gy /GA /GR- /Zi /Fe:imgview.exe ..\imgview.cpp ^
 	/link /NODEFAULTLIB kernel32.lib user32.lib gdi32.lib ole32.lib shlwapi.lib shell32.lib advapi32.lib comctl32.lib uuid.lib gdiplus.lib ^
 	/subsystem:windows /OPT:REF /OPT:ICF /STACK:0x100000,0x100000 ^
   	&& imgview 
+
+popd
+popd

--- a/imgview.cpp
+++ b/imgview.cpp
@@ -15,6 +15,19 @@ using namespace Gdiplus::DllExports;
 
 /////////////////////////////////////////////////////////////////
 
+#ifdef __cplusplus 
+extern "C"
+#endif
+__declspec(naked) void _ftol2_sse()
+{
+	__asm
+	{
+		fistp dword ptr [esp-4]
+		mov   eax,[esp-4]
+		ret
+	}
+}
+
 extern "C" int _fltused = 0;
 typedef HRESULT (*GetDpiForMonitorType)(HMONITOR hmonitor, MONITOR_DPI_TYPE dpiType, UINT *dpiX, UINT *dpiY);
 typedef BOOL (*SetProcessDpiAwarenessContextType)(DPI_AWARENESS_CONTEXT value);
@@ -670,7 +683,7 @@ LRESULT CALLBACK FrameProcedure(HWND window, UINT message, WPARAM wParam, LPARAM
 	return 0;
 }
 
-DWORD GetFolderContents(void *_filePath) {
+DWORD WINAPI GetFolderContents(void *_filePath) {
 	wchar_t *filePath = (wchar_t *) _filePath;
 	wchar_t pathBuffer[MAX_PATH + 4];
 	


### PR DESCRIPTION
Currently, build.bat assumes that it's run from {cwd}/build
directory. This might not always be the case, so the present
fix proposes a solution without modifying any functionality.

set cd=%~dp0  -> set "cd" variable to the folder build.bat is in
set build=%cd%build -> set the build directory to be in working dir
pushd %cd% -> go to the working dir
IF NOT EXIST build (mkdir build) -> create build directory if none
pushd %build% -> go to the build directory

popd -> return to %cd%
popd -> return to wherever the call originated